### PR TITLE
Add structured query handling for expense summaries

### DIFF
--- a/src/agents/utils/db_repo.py
+++ b/src/agents/utils/db_repo.py
@@ -19,6 +19,7 @@ class LedgerDB(Protocol):
 
     def init(self) -> None: ...
     def insert_transaction(self, p: Dict[str, Any]) -> int: ...
+    def summarize_transactions(self, plan: Dict[str, Any]) -> Dict[str, Any]: ...
 
 
 # ---------------------------
@@ -78,6 +79,116 @@ class SQLiteLedgerDB:
                 ),
             )
             return int(cur.lastrowid)
+
+    @staticmethod
+    def _start_bound(date_str: str | None) -> str | None:
+        if not date_str:
+            return None
+        if "T" in date_str:
+            return date_str
+        return f"{date_str}T00:00"
+
+    @staticmethod
+    def _end_bound(date_str: str | None) -> str | None:
+        if not date_str:
+            return None
+        if "T" in date_str:
+            base = dt.datetime.fromisoformat(date_str.replace("Z", "")) + dt.timedelta(minutes=1)
+            return base.isoformat(timespec="minutes")
+        end_date = dt.date.fromisoformat(date_str) + dt.timedelta(days=1)
+        return f"{end_date.isoformat()}T00:00"
+
+    def summarize_transactions(self, plan: Dict[str, Any]) -> Dict[str, Any]:
+        metric = (plan.get("metric") or "sum").lower()
+        where: list[str] = []
+        params: list[Any] = []
+
+        start_bound = self._start_bound(plan.get("start_iso"))
+        if start_bound:
+            where.append("occurred_at >= ?")
+            params.append(start_bound)
+
+        end_exclusive = plan.get("_end_exclusive")
+        end_bound = None
+        if end_exclusive:
+            end_bound = self._start_bound(end_exclusive)
+        else:
+            end_bound = self._end_bound(plan.get("end_iso"))
+        if end_bound:
+            where.append("occurred_at < ?")
+            params.append(end_bound)
+
+        keywords = [kw.lower() for kw in plan.get("item_keywords", []) if kw]
+        if keywords:
+            clause = " OR ".join("LOWER(item) LIKE ?" for _ in keywords)
+            where.append(f"({clause})")
+            params.extend([f"%{kw}%" for kw in keywords])
+
+        categories = [c for c in plan.get("categories", []) if c]
+        if categories:
+            placeholders = ",".join("?" for _ in categories)
+            where.append(f"category IN ({placeholders})")
+            params.extend(categories)
+
+        merchants = [m for m in plan.get("merchants", []) if m]
+        if merchants:
+            placeholders = ",".join("?" for _ in merchants)
+            where.append(f"merchant IN ({placeholders})")
+            params.extend(merchants)
+
+        notes = plan.get("notes")
+        if notes:
+            where.append("LOWER(note) LIKE ?")
+            params.append(f"%{str(notes).lower()}%")
+
+        where_sql = " AND ".join(where) if where else "1=1"
+
+        select_cols = ["COUNT(*) AS total_rows"]
+        if metric in {"sum", "avg"}:
+            select_cols.append("COALESCE(SUM(amount_cents), 0) AS total_cents")
+        if metric == "avg":
+            select_cols.append("COALESCE(AVG(amount_cents), 0) AS avg_cents")
+
+        agg_sql = f"SELECT {', '.join(select_cols)} FROM transactions WHERE {where_sql}"
+
+        with self._conn() as conn:
+            cur = conn.execute(agg_sql, params)
+            row = cur.fetchone()
+            total_rows = int(row[0]) if row else 0
+            total_cents = None
+            avg_cents = None
+            if metric in {"sum", "avg"} and row and len(row) > 1:
+                total_cents = int(row[1])
+            if metric == "avg" and row and len(row) > 2:
+                avg_cents = float(row[2])
+
+            details: list[Dict[str, Any]] = []
+            if metric == "list":
+                detail_sql = (
+                    f"SELECT occurred_at, item, amount_cents, currency, category, merchant, note "
+                    f"FROM transactions WHERE {where_sql} ORDER BY occurred_at ASC"
+                )
+                dcur = conn.execute(detail_sql, params)
+                columns = [desc[0] for desc in dcur.description]
+                details = [dict(zip(columns, record)) for record in dcur.fetchall()]
+
+        result: Dict[str, Any] = {
+            "status": "ok",
+            "metric": metric,
+            "total_rows": total_rows,
+            "total_cents": total_cents,
+            "total_amount_yuan": (total_cents / 100) if total_cents is not None else None,
+            "avg_cents": avg_cents,
+            "avg_amount_yuan": (avg_cents / 100) if avg_cents is not None else None,
+            "details": details,
+        }
+        if plan.get("time_scope"):
+            result["time_scope"] = plan.get("time_scope")
+        if start_bound:
+            result["start_iso"] = plan.get("start_iso")
+        if plan.get("end_iso"):
+            result["end_iso"] = plan.get("end_iso")
+        return result
 
 
 
@@ -163,6 +274,114 @@ class MySQLLedgerDB:
                 txn_id = int(cur.lastrowid)
             conn.commit()
         return txn_id
+
+    @staticmethod
+    def _start_bound(date_str: str | None) -> str | None:
+        if not date_str:
+            return None
+        if "T" in date_str:
+            dt_obj = dt.datetime.fromisoformat(date_str.replace("Z", ""))
+        else:
+            dt_obj = dt.datetime.fromisoformat(f"{date_str}T00:00")
+        return dt_obj.strftime("%Y-%m-%d %H:%M:%S")
+
+    @staticmethod
+    def _end_bound(date_str: str | None) -> str | None:
+        if not date_str:
+            return None
+        if "T" in date_str:
+            dt_obj = dt.datetime.fromisoformat(date_str.replace("Z", "")) + dt.timedelta(minutes=1)
+        else:
+            dt_obj = dt.datetime.fromisoformat(f"{date_str}T00:00") + dt.timedelta(days=1)
+        return dt_obj.strftime("%Y-%m-%d %H:%M:%S")
+
+    def summarize_transactions(self, plan: Dict[str, Any]) -> Dict[str, Any]:
+        metric = (plan.get("metric") or "sum").lower()
+        where: list[str] = []
+        params: list[Any] = []
+
+        start_bound = self._start_bound(plan.get("start_iso"))
+        if start_bound:
+            where.append("occurred_at >= %s")
+            params.append(start_bound)
+
+        end_exclusive = plan.get("_end_exclusive")
+        end_bound = self._start_bound(end_exclusive) if end_exclusive else self._end_bound(plan.get("end_iso"))
+        if end_bound:
+            where.append("occurred_at < %s")
+            params.append(end_bound)
+
+        keywords = [kw.lower() for kw in plan.get("item_keywords", []) if kw]
+        if keywords:
+            clause = " OR ".join("LOWER(item) LIKE %s" for _ in keywords)
+            where.append(f"({clause})")
+            params.extend([f"%{kw}%" for kw in keywords])
+
+        categories = [c for c in plan.get("categories", []) if c]
+        if categories:
+            placeholders = ",".join(["%s"] * len(categories))
+            where.append(f"category IN ({placeholders})")
+            params.extend(categories)
+
+        merchants = [m for m in plan.get("merchants", []) if m]
+        if merchants:
+            placeholders = ",".join(["%s"] * len(merchants))
+            where.append(f"merchant IN ({placeholders})")
+            params.extend(merchants)
+
+        notes = plan.get("notes")
+        if notes:
+            where.append("LOWER(note) LIKE %s")
+            params.append(f"%{str(notes).lower()}%")
+
+        where_sql = " AND ".join(where) if where else "1=1"
+
+        select_cols = ["COUNT(*) AS total_rows"]
+        if metric in {"sum", "avg"}:
+            select_cols.append("COALESCE(SUM(amount_cents), 0) AS total_cents")
+        if metric == "avg":
+            select_cols.append("COALESCE(AVG(amount_cents), 0) AS avg_cents")
+
+        agg_sql = f"SELECT {', '.join(select_cols)} FROM transactions WHERE {where_sql}"
+
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(agg_sql, params)
+                row = cur.fetchone()
+                total_rows = int(row["total_rows"]) if row else 0
+                total_cents = None
+                avg_cents = None
+                if metric in {"sum", "avg"} and row and "total_cents" in row:
+                    total_cents = int(row["total_cents"])
+                if metric == "avg" and row and "avg_cents" in row:
+                    avg_cents = float(row["avg_cents"])
+
+                details: list[Dict[str, Any]] = []
+                if metric == "list":
+                    detail_sql = (
+                        f"SELECT occurred_at, item, amount_cents, currency, category, merchant, note "
+                        f"FROM transactions WHERE {where_sql} ORDER BY occurred_at ASC"
+                    )
+                    cur.execute(detail_sql, params)
+                    details = cur.fetchall()
+
+        result: Dict[str, Any] = {
+            "status": "ok",
+            "metric": metric,
+            "total_rows": total_rows,
+            "total_cents": total_cents,
+            "total_amount_yuan": (total_cents / 100) if total_cents is not None else None,
+            "avg_cents": avg_cents,
+            "avg_amount_yuan": (avg_cents / 100) if avg_cents is not None else None,
+            "details": details,
+        }
+        if plan.get("time_scope"):
+            result["time_scope"] = plan.get("time_scope")
+        if plan.get("start_iso"):
+            result["start_iso"] = plan.get("start_iso")
+        if plan.get("end_iso"):
+            result["end_iso"] = plan.get("end_iso")
+        return result
 
 
 


### PR DESCRIPTION
## Summary
- extend the expense tracker agent with a query_summary intent, structured query planning, and deterministic execution before final responses
- expose a summarize_transactions API on the database layer with SQLite/MySQL implementations that support filters and aggregations
- wire new graph nodes and state snapshot fields so final replies surface factual query results

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68df9dbdecd0832f9983f97056871477